### PR TITLE
Updated Kapture-Client.java -> saveAll to use RestTemplate.exchange i…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>com.kaleido</groupId>
     <artifactId>kapture-client</artifactId>
-    <version>3.2.13</version>
+    <version>3.2.14</version>
     <name>kapture-client</name>
     <packaging>jar</packaging>
 

--- a/src/main/java/com/kaleido/kaptureclient/client/KaptureClient.java
+++ b/src/main/java/com/kaleido/kaptureclient/client/KaptureClient.java
@@ -296,7 +296,12 @@ public class KaptureClient<E> {
      * set.
      */
     public ResponseEntity<List<E>> saveAll(@Valid List<E> entityList) {
-        return retryTemplate.execute(arg0 -> restTemplate.postForObject(endpoint + "/save-all", entityList, ResponseEntity.class)
+        return retryTemplate.execute(arg0 -> {
+                HttpEntity<Object> requestEntity = new HttpEntity<Object>(entityList);
+                return restTemplate
+                        .exchange(endpoint + "/save-all", HttpMethod.POST, requestEntity, new ParameterizedTypeReference<List<E>>() {
+                        });
+                }
         );
     }
 


### PR DESCRIPTION
Kapture-Client _**Version 3.2.14**_
Changes:
Kapture-Client.java
- Updated saveAll method to use RestTemplate.exchange instead of RestTemplate.postForObject to eliminate deserialization error
pom.xml
- Updated client version from 3.2.13 to 3.2.14

Closes #4 